### PR TITLE
Bug in setTab means tab stops are never set

### DIFF
--- a/lib/term_state.js
+++ b/lib/term_state.js
@@ -908,7 +908,7 @@ TermState.prototype.setTab = function(pos) {
 		pos = this.cursor.x;
 	}
 	// Only add the tab position if it is not there already
-	if (~myUtil.indexOf(this._tabs, pos)) {
+	if (~~myUtil.indexOf(this._tabs, pos)) {
 		this._tabs.push(pos);
 		this._tabs.sort();
 	}


### PR DESCRIPTION
~myUtil.indexOf(this._tabs, pos) returns 0 when pos is not in this_.tabs, so that conditional never equals true. 

Changing it !~myUtil.indexOf(this._tabs, pos)  fixes it.